### PR TITLE
quick fixes

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,10 +17,3 @@ POMDPs = "0.9"
 POMDPTools = "0.1"
 Parameters = "0.12"
 julia = "1"
-
-[extras]
-POMDPModels = "355abbd5-f08e-5560-ac9e-8b5f2592a0ca"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-
-[targets]
-test = ["POMDPModels", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -8,12 +8,10 @@ version = "0.4.3"
 POMDPLinter = "f3bd98c0-eb40-45e2-9eb1-f2763262d755"
 POMDPTools = "7588e00f-9cae-40de-98dc-e0c70c48cdd7"
 POMDPs = "a93abf59-7444-517b-a68a-c42f96afdd7d"
-Parameters = "d96e819e-fc66-5662-9728-84c9c7592b0a"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [compat]
 POMDPLinter = "0.1"
-POMDPs = "0.9"
 POMDPTools = "0.1"
-Parameters = "0.12"
+POMDPs = "0.9"
 julia = "1"

--- a/src/TabularTDLearning.jl
+++ b/src/TabularTDLearning.jl
@@ -3,7 +3,6 @@ module TabularTDLearning
 using POMDPs
 using POMDPLinter
 using POMDPTools
-using Parameters
 using Random
 
 import POMDPs: Solver, solve, Policy

--- a/src/q_learn.jl
+++ b/src/q_learn.jl
@@ -25,7 +25,7 @@ Parameters:
     print information during training
     default: `true`
 """
-@with_kw mutable struct QLearningSolver{E<:ExplorationPolicy} <: Solver
+Base.@kwdef mutable struct QLearningSolver{E<:ExplorationPolicy} <: Solver
    n_episodes::Int64 = 100
    max_episode_length::Int64 = 100
    learning_rate::Float64 = 0.001

--- a/src/sarsa.jl
+++ b/src/sarsa.jl
@@ -25,7 +25,7 @@ Parameters:
     print information during training
     default: `true`
 """
-Base.@kwdef mutable struct SARSASolver{E<:ExplorationPolicy} <: Solver
+Base.@kwdef mutable struct SARSASolver{E<:ExplorationPolicy, RNG<:AbstractRNG} <: Solver
    n_episodes::Int64 = 100
    max_episode_length::Int64 = 100
    learning_rate::Float64 = 0.001
@@ -33,18 +33,18 @@ Base.@kwdef mutable struct SARSASolver{E<:ExplorationPolicy} <: Solver
    Q_vals::Union{Nothing, Matrix{Float64}} = nothing
    eval_every::Int64 = 10
    n_eval_traj::Int64 = 20
-   rng::AbstractRNG = Random.GLOBAL_RNG
+   rng::RNG = Random.GLOBAL_RNG
    verbose::Bool = true
 end
 
 function solve(solver::SARSASolver, mdp::Union{MDP,POMDP})
-    rng = solver.rng
-    if solver.Q_vals === nothing
-        Q = zeros(length(states(mdp)), length(actions(mdp)))
+    (;rng, exploration_policy) = solver
+    Q = if isnothing(solver.Q_vals)
+        zeros(length(states(mdp)), length(actions(mdp)))
     else
-        Q = solver.Q_vals
-    end
-    exploration_policy = solver.exploration_policy
+        solver.Q_vals
+    end::Matrix{Float64}
+
     sim = RolloutSimulator(rng=rng, max_steps=solver.max_episode_length)
 
     on_policy = ValuePolicy(mdp, Q)
@@ -70,7 +70,7 @@ function solve(solver::SARSASolver, mdp::Union{MDP,POMDP})
             for traj in 1:solver.n_eval_traj
                 r_tot += simulate(sim, mdp, on_policy, rand(rng, initialstate(mdp)))
             end
-            solver.verbose ? println("On Iteration $i, Returns: $(r_tot/solver.n_eval_traj)") : nothing
+            solver.verbose && println("On Iteration $i, Returns: $(r_tot/solver.n_eval_traj)")
         end
     end
     return on_policy

--- a/src/sarsa.jl
+++ b/src/sarsa.jl
@@ -25,7 +25,7 @@ Parameters:
     print information during training
     default: `true`
 """
-@with_kw mutable struct SARSASolver{E<:ExplorationPolicy} <: Solver
+Base.@kwdef mutable struct SARSASolver{E<:ExplorationPolicy} <: Solver
    n_episodes::Int64 = 100
    max_episode_length::Int64 = 100
    learning_rate::Float64 = 0.001

--- a/src/sarsa_lambda.jl
+++ b/src/sarsa_lambda.jl
@@ -28,7 +28,7 @@ Parameters:
     print information during training
     default: `true`
 """
-@with_kw mutable struct SARSALambdaSolver{E<:ExplorationPolicy} <: Solver
+Base.@kwdef mutable struct SARSALambdaSolver{E<:ExplorationPolicy} <: Solver
    n_episodes::Int64 = 100
    max_episode_length::Int64 = 100
    learning_rate::Float64 = 0.001

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,0 +1,7 @@
+[deps]
+POMDPLinter = "f3bd98c0-eb40-45e2-9eb1-f2763262d755"
+POMDPModels = "355abbd5-f08e-5560-ac9e-8b5f2592a0ca"
+POMDPTools = "7588e00f-9cae-40de-98dc-e0c70c48cdd7"
+POMDPs = "a93abf59-7444-517b-a68a-c42f96afdd7d"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
For benchmarking, solver configurations are the same as in test files, except `n_episodes = 1_000`.

# Q learning

Before

```julia
BenchmarkTools.Trial: 749 samples with 1 evaluation.
 Range (min … max):  5.293 ms … 10.363 ms  ┊ GC (min … max): 0.00% … 33.24%
 Time  (median):     6.081 ms              ┊ GC (median):    0.00%
 Time  (mean ± σ):   6.674 ms ±  1.403 ms  ┊ GC (mean ± σ):  9.94% ± 14.36%

      ▂▄▅▆▇█▅▄                                                
  ▂▃▄▇██████████▇▄▃▃▂▃▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▂▃▃▄▄▆▄▅▅▆▄▄▃▄ ▃
  5.29 ms        Histogram: frequency by time        9.95 ms <

 Memory estimate: 12.36 MiB, allocs estimate: 208948.
```

After

```julia
BenchmarkTools.Trial: 1195 samples with 1 evaluation.
 Range (min … max):  3.196 ms … 9.009 ms  ┊ GC (min … max):  0.00% … 57.34%
 Time  (median):     3.647 ms             ┊ GC (median):     0.00%
 Time  (mean ± σ):   4.181 ms ± 1.529 ms  ┊ GC (mean ± σ):  12.63% ± 17.32%

    ▄▆█▇                                                     
  ▃▆████▇▆▃▂▂▁▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▂▂▃▃▃▃▄▃▃ ▃
  3.2 ms         Histogram: frequency by time       8.62 ms <

 Memory estimate: 8.24 MiB, allocs estimate: 129217.
```

# SARSA

Before

```julia
BenchmarkTools.Trial: 678 samples with 1 evaluation.
 Range (min … max):  5.886 ms … 10.119 ms  ┊ GC (min … max): 0.00% … 22.13%
 Time  (median):     6.815 ms              ┊ GC (median):    0.00%
 Time  (mean ± σ):   7.369 ms ±  1.094 ms  ┊ GC (mean ± σ):  9.90% ± 11.79%

        ▁▂█▄▂▇▅▂▃▁                                            
  ▂▂▃▄▆▅████████████▅▅▅▄▄▃▃▂▁▂▁▂▁▁▁▁▂▂▁▂▂▃▃▄▆▆▅█▇█▆▆▇▆▆▆▄▃▃▃ ▄
  5.89 ms        Histogram: frequency by time        9.46 ms <

 Memory estimate: 12.55 MiB, allocs estimate: 220650.
```

After

```julia
BenchmarkTools.Trial: 768 samples with 1 evaluation.
 Range (min … max):  5.121 ms … 11.150 ms  ┊ GC (min … max): 0.00% … 40.97%
 Time  (median):     5.900 ms              ┊ GC (median):    0.00%
 Time  (mean ± σ):   6.509 ms ±  1.558 ms  ┊ GC (mean ± σ):  9.74% ± 14.55%

     ▃▆██▇▅▇▂▁                                                
  ▃▄▇██████████▇▄▃▂▃▁▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▂▁▃▃▃▄▅▅▅▅▄▃▃▄ ▃
  5.12 ms        Histogram: frequency by time        10.5 ms <

 Memory estimate: 10.26 MiB, allocs estimate: 160562.
```

# SARSA-lambda

Before

```julia
BenchmarkTools.Trial: 66 samples with 1 evaluation.
 Range (min … max):  69.143 ms … 82.642 ms  ┊ GC (min … max): 12.24% … 14.93%
 Time  (median):     76.713 ms              ┊ GC (median):    11.49%
 Time  (mean ± σ):   76.025 ms ±  2.978 ms  ┊ GC (mean ± σ):  11.74% ±  1.15%

                              ▅       █  ▅▅   ▂                
  ▅▅▁█▅▅▁▁█▁▁▁▁▁▁▅▁▁▁▅█▅▅▁█▅▅██▁▅▁██▁██▅███▅▅████▅█▅▁▅▁▁▅▁▁▁▅ ▁
  69.1 ms         Histogram: frequency by time        81.4 ms <

 Memory estimate: 160.64 MiB, allocs estimate: 326811.
```

After

```julia
BenchmarkTools.Trial: 86 samples with 1 evaluation.
 Range (min … max):  51.804 ms … 72.022 ms  ┊ GC (min … max): 13.76% … 18.35%
 Time  (median):     58.443 ms              ┊ GC (median):    12.77%
 Time  (mean ± σ):   58.534 ms ±  3.388 ms  ┊ GC (mean ± σ):  14.89% ±  2.56%

                 █▅ ▂   ▂ ▂▂ ▂  ▂▂▂  ▂▂   ▂                    
  ▅▅▁█▁▁▅▁▁▅▁▁▁█▅██▅█▅▅▅█▁████▁▅███▅▁██████▅▅▁▅█▅█▁██▅▅▅▅█▅▁▅ ▁
  51.8 ms         Histogram: frequency by time        64.4 ms <

 Memory estimate: 157.03 MiB, allocs estimate: 263353.
```